### PR TITLE
updated gems, specifically rubocop 0.45 to 0.52.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
-source 'https://gems.dgvz.net'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,57 @@
 PATH
   remote: .
   specs:
-    digibits (1.5)
-      rubocop (~> 0.42.1.pre)
+    digivizer-style (1.1)
+      rubocop (~> 0.45)
 
 GEM
   remote: https://rubygems.org/
-  remote: https://gems.dgvz.net/
   specs:
-    ast (2.3.0)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    ast (2.4.0)
+    claide (1.0.2)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
+    colored2 (3.1.2)
+    cork (0.3.0)
+      colored2 (~> 3.1)
+    danger (5.5.10)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (~> 0.9)
+      faraday-http-cache (~> 1.0)
+      git (~> 1)
+      kramdown (~> 1.5)
+      no_proxy_fix
+      octokit (~> 4.7)
+      terminal-table (~> 1)
+    danger-rubocop (0.6.0)
+      danger
+      rubocop
     diff-lcs (1.2.5)
-    parser (2.3.1.2)
-      ast (~> 2.2)
+    faraday (0.14.0)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.1)
+      faraday (~> 0.8)
+    git (1.3.0)
+    kramdown (1.16.2)
+    multipart-post (2.0.0)
+    nap (1.1.0)
+    no_proxy_fix (0.1.2)
+    octokit (4.8.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    open4 (1.3.4)
+    parallel (1.12.1)
+    parser (2.5.0.0)
+      ast (~> 2.4.0)
     powerpack (0.1.1)
-    rainbow (2.1.0)
+    public_suffix (3.0.2)
+    rainbow (3.0.0)
     rake (11.2.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -28,23 +66,31 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.42.1.pre)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.52.1)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
-    unicode-display_width (1.1.0)
+    ruby-progressbar (1.9.0)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    unicode-display_width (1.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 1.3)
-  digibits!
-  rake
-  rspec
+  danger
+  danger-rubocop
+  digivizer-style!
+  rake (~> 11.2)
+  rspec (~> 3.5)
 
 BUNDLED WITH
-   1.11.2
+   1.16.1

--- a/digivizer-style.gemspec
+++ b/digivizer-style.gemspec
@@ -7,7 +7,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'digivizer-style'
-  spec.version       = '1.1'
+  spec.version       = '1.2'
   spec.authors       = ['Digivizer Developer']
   spec.email         = ['dev-accounts@digivizer.com']
   spec.description   = 'The Digivizer Manual of Style'


### PR DESCRIPTION
additionally removed "source 'https://gems.dgvz.net'" from gemfile as it is outdated and causes issues with bundler