### PR TITLE
Use default (ruby19) hash syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,9 +33,6 @@ Layout/SpaceInsideHashLiteralBraces:
 Layout/SpaceBeforeFirstArg:
   Enabled: false
 
-Style/HashSyntax:
-  EnforcedStyle: hash_rockets
-
 Style/ColonMethodCall:
   Enabled: false
 


### PR DESCRIPTION
This should prevent many lint errors that we ignore.